### PR TITLE
Allow setting commands from files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -39,6 +39,7 @@ TESTS += tests/install/from-file.sh
 TESTS += tests/post/post-install.sh
 TESTS += tests/post/cleanup.sh
 TESTS += tests/post/from-file.sh
+TESTS += tests/post/from-file-error-handling.sh
 
 buildsh_CFLAGS = -ggdb -pedantic -Wall -Wextra
 buildsh_SOURCES = src/main.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,7 @@ TESTS += tests/extract/custom-archive-name.sh
 
 TESTS += tests/source-setup/run-commands.sh
 TESTS += tests/source-setup/build-dir.sh
+TESTS += tests/source-setup/from-file.sh
 
 TESTS += tests/configure/default-configure.sh
 TESTS += tests/configure/disabled.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,6 +22,7 @@ TESTS += tests/build/disabled.sh
 TESTS += tests/build/make-max-jobs.sh
 TESTS += tests/build/make-targets.sh
 TESTS += tests/build/custom-commands.sh
+TESTS += tests/build/from-file.sh
 
 TESTS += tests/test/default-off.sh
 TESTS += tests/test/default-make-check.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,7 @@ TESTS += tests/build/from-file.sh
 TESTS += tests/test/default-off.sh
 TESTS += tests/test/default-make-check.sh
 TESTS += tests/test/custom.sh
+TESTS += tests/test/from-file.sh
 
 TESTS += tests/install/default-make-install.sh
 TESTS += tests/install/destdir.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,6 +16,7 @@ TESTS += tests/configure/options.sh
 TESTS += tests/configure/in-custom-dir.sh
 TESTS += tests/configure/prefix-env.sh
 TESTS += tests/configure/custom-commands.sh
+TESTS += tests/configure/from-file.sh
 
 TESTS += tests/build/default-make.sh
 TESTS += tests/build/disabled.sh
@@ -33,9 +34,11 @@ TESTS += tests/install/default-make-install.sh
 TESTS += tests/install/destdir.sh
 TESTS += tests/install/sudo.sh
 TESTS += tests/install/custom.sh
+TESTS += tests/install/from-file.sh
 
 TESTS += tests/post/post-install.sh
 TESTS += tests/post/cleanup.sh
+TESTS += tests/post/from-file.sh
 
 buildsh_CFLAGS = -ggdb -pedantic -Wall -Wextra
 buildsh_SOURCES = src/main.c

--- a/src/actions/build.c
+++ b/src/actions/build.c
@@ -7,3 +7,7 @@ void add_build_command(struct Settings *settings, const char *command) {
 void add_make_option(struct Settings *settings, const char *option) {
     CONCAT_PRINTF(settings->make_options, " %s", option);
 }
+
+void add_build_file(struct Settings *settings, const char *file) {
+    concat_file(settings->build_commands, file);
+}

--- a/src/actions/configure.c
+++ b/src/actions/configure.c
@@ -19,3 +19,7 @@ void add_configure_value(struct Settings *settings, const char *value) {
 void add_configure_command(struct Settings *settings, const char *command) {
     CONCAT_LINE(settings->configure_commands, command);
 }
+
+void add_configure_file(struct Settings *settings, const char *file) {
+    concat_file(settings->configure_commands, file);
+}

--- a/src/actions/install.c
+++ b/src/actions/install.c
@@ -7,3 +7,7 @@ void set_makeinstall_destdir(struct Settings *settings, const char *path) {
 void add_install_command(struct Settings *settings, const char *command) {
     CONCAT_LINE(settings->install_commands, command);
 }
+
+void add_install_file(struct Settings *settings, const char *file) {
+    concat_file(settings->install_commands, file);
+}

--- a/src/actions/post.c
+++ b/src/actions/post.c
@@ -3,3 +3,7 @@
 void add_post_command(struct Settings *settings, const char *command) {
     CONCAT_LINE(settings->install_post, command);
 }
+
+void add_post_file(struct Settings *settings, const char *file) {
+    concat_file(settings->install_post, file);
+}

--- a/src/actions/source-setup.c
+++ b/src/actions/source-setup.c
@@ -3,3 +3,7 @@
 void add_source_setup_command(struct Settings *settings, const char *command) {
     CONCAT_LINE(settings->source_setup, command);
 }
+
+void add_source_setup_file(struct Settings *settings, const char *file) {
+    concat_file(settings->source_setup, file);
+}

--- a/src/generator.c
+++ b/src/generator.c
@@ -1,4 +1,5 @@
 #include "generator.h"
+#include <stdlib.h>
 
 #define EMPTY_LINE puts("");
 
@@ -12,15 +13,20 @@ int run(const char *commands) {
 void concat_file(const char *destination, const char *file) {
     FILE *fp = fopen(file, "r");
     if (fp == 0) {
-        return;
+        fprintf(stderr, "error reading file %s\n", file);
+        exit(EXIT_FAILURE);
     }
 
     char buffer[8192];
-    fread(buffer, sizeof(char), 8192, fp);
+    int size = fread(buffer, sizeof(char), 8192, fp);
+    fclose(fp);
+
+    if (size == 8192) {
+        fprintf(stderr, "file %s too large\n", file);
+        exit(EXIT_FAILURE);
+    }
 
     CONCAT_LINE(destination, buffer);
-
-    fclose(fp);
 }
 
 // helper generator functions

--- a/src/generator.c
+++ b/src/generator.c
@@ -9,6 +9,20 @@ int run(const char *commands) {
     return 1;
 }
 
+void concat_file(const char *destination, const char *file) {
+    FILE *fp = fopen(file, "r");
+    if (fp == 0) {
+        return;
+    }
+
+    char buffer[8192];
+    fread(buffer, sizeof(char), 8192, fp);
+
+    CONCAT_LINE(destination, buffer);
+
+    fclose(fp);
+}
+
 // helper generator functions
 
 void generator_create_build_dir(char *commands) {

--- a/src/generator.h
+++ b/src/generator.h
@@ -60,6 +60,7 @@ void add_configure_command(struct Settings *settings, const char *command);
 
 void add_build_command(struct Settings *settings, const char *command);
 void add_make_option(struct Settings *settings, const char *option);
+void add_build_file(struct Settings *settings, const char *file);
 
 void set_makeinstall_destdir(struct Settings *settings, const char *path);
 void add_install_command(struct Settings *settings, const char *command);

--- a/src/generator.h
+++ b/src/generator.h
@@ -50,6 +50,7 @@ void generator_init(struct Settings *settings);
 void generator_finalize_setup(struct Settings *settings);
 
 void add_source_setup_command(struct Settings *settings, const char *command);
+void add_source_setup_file(struct Settings *settings, const char *command);
 
 void set_configure_dir(struct Settings *settings, const char *path);
 void add_configure_envvar(struct Settings *settings, const char *envvar);

--- a/src/generator.h
+++ b/src/generator.h
@@ -44,6 +44,7 @@ struct Settings {
 };
 
 int run(const char *commands);
+void concat_file(const char *buffer, const char *file);
 
 void generator_init(struct Settings *settings);
 void generator_finalize_setup(struct Settings *settings);

--- a/src/generator.h
+++ b/src/generator.h
@@ -57,6 +57,7 @@ void add_configure_envvar(struct Settings *settings, const char *envvar);
 void add_configure_option(struct Settings *settings, const char *option);
 void add_configure_value(struct Settings *settings, const char *value);
 void add_configure_command(struct Settings *settings, const char *command);
+void add_configure_file(struct Settings *settings, const char *file);
 
 void add_build_command(struct Settings *settings, const char *command);
 void add_make_option(struct Settings *settings, const char *option);
@@ -64,7 +65,9 @@ void add_build_file(struct Settings *settings, const char *file);
 
 void set_makeinstall_destdir(struct Settings *settings, const char *path);
 void add_install_command(struct Settings *settings, const char *command);
+void add_install_file(struct Settings *settings, const char *file);
 
 void add_post_command(struct Settings *settings, const char *command);
+void add_post_file(struct Settings *settings, const char *file);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -71,6 +71,7 @@ void parse_arguments(int argc, char *argv[], struct Settings *settings) {
         {"max-jobs",                required_argument, 0, 0},
         {"post",                    required_argument, 0, 0},
         {"source-setup",            required_argument, 0, 0},
+        {"source-setup-file",       required_argument, 0, 0},
         {"sudo",                    no_argument      , &settings->install_sudo, 1},
         {"test",                    optional_argument, &settings->do_test, 1},
         {0, 0, 0, 0}
@@ -139,6 +140,8 @@ void parse_long_option(const char *name, const char *value, struct Settings *set
         add_post_command(settings, value);
     } else if (strcmp("source-setup", name) == 0) {
         add_source_setup_command(settings, value);
+    } else if (strcmp("source-setup-file", name) == 0) {
+        add_source_setup_file(settings, value);
     } else {
         fprintf(stderr, "long option not implemented: %s\n", name);
         exit(EXIT_FAILURE);

--- a/src/main.c
+++ b/src/main.c
@@ -138,11 +138,11 @@ void parse_long_option(const char *name, const char *value, struct Settings *set
     } else if (strcmp("configure-using", name) == 0) {
         add_configure_command(settings, value);
     } else if (strcmp("configure-file", name) == 0) {
-        concat_file(settings->configure_commands, value);
+        add_configure_file(settings, value);
     } else if (strcmp("install-using", name) == 0) {
         add_install_command(settings, value);
     } else if (strcmp("install-file", name) == 0) {
-        concat_file(settings->install_commands, value);
+        add_install_file(settings, value);
     } else if (strcmp("make", name) == 0) {
         add_make_option(settings, value);
     } else if (strcmp("max-jobs", name) == 0) {
@@ -150,7 +150,7 @@ void parse_long_option(const char *name, const char *value, struct Settings *set
     } else if (strcmp("post", name) == 0) {
         add_post_command(settings, value);
     } else if (strcmp("post-file", name) == 0) {
-        concat_file(settings->install_post, value);
+        add_post_file(settings, value);
     } else if (strcmp("source-setup", name) == 0) {
         add_source_setup_command(settings, value);
     } else if (strcmp("source-setup-file", name) == 0) {

--- a/src/main.c
+++ b/src/main.c
@@ -67,10 +67,13 @@ void parse_arguments(int argc, char *argv[], struct Settings *settings) {
         {"configure",               required_argument, 0, 0},
         {"configure-val",           required_argument, 0, 0},
         {"configure-using",         required_argument, 0, 0},
+        {"configure-file",          required_argument, 0, 0},
         {"install-using",           required_argument, 0, 0},
+        {"install-file",            required_argument, 0, 0},
         {"make",                    required_argument, 0, 0},
         {"max-jobs",                required_argument, 0, 0},
         {"post",                    required_argument, 0, 0},
+        {"post-file",               required_argument, 0, 0},
         {"source-setup",            required_argument, 0, 0},
         {"source-setup-file",       required_argument, 0, 0},
         {"sudo",                    no_argument      , &settings->install_sudo, 1},
@@ -134,14 +137,20 @@ void parse_long_option(const char *name, const char *value, struct Settings *set
         add_configure_value(settings, value);
     } else if (strcmp("configure-using", name) == 0) {
         add_configure_command(settings, value);
+    } else if (strcmp("configure-file", name) == 0) {
+        concat_file(settings->configure_commands, value);
     } else if (strcmp("install-using", name) == 0) {
         add_install_command(settings, value);
+    } else if (strcmp("install-file", name) == 0) {
+        concat_file(settings->install_commands, value);
     } else if (strcmp("make", name) == 0) {
         add_make_option(settings, value);
     } else if (strcmp("max-jobs", name) == 0) {
         settings->max_make_jobs = atoi(value);
     } else if (strcmp("post", name) == 0) {
         add_post_command(settings, value);
+    } else if (strcmp("post-file", name) == 0) {
+        concat_file(settings->install_post, value);
     } else if (strcmp("source-setup", name) == 0) {
         add_source_setup_command(settings, value);
     } else if (strcmp("source-setup-file", name) == 0) {

--- a/src/main.c
+++ b/src/main.c
@@ -59,6 +59,7 @@ void parse_arguments(int argc, char *argv[], struct Settings *settings) {
         {"archive",                 required_argument, 0, 'a'},
         {"build-outside-sources",   no_argument      , &settings->build_outside_sources, 1},
         {"build-using",             required_argument, 0, 0},
+        {"build-file",              required_argument, 0, 0},
         {"no-build",                no_argument     , &settings->do_build, 0},
         {"no-configure",            no_argument     , &settings->do_configure, 0},
         {"configure-dir",           required_argument, 0, 0},
@@ -120,6 +121,8 @@ void parse_flag_set(const char *name, const char *value, struct Settings *settin
 void parse_long_option(const char *name, const char *value, struct Settings *settings) {
     if (strcmp("build-using", name) == 0) {
         add_build_command(settings, value);
+    } else if (strcmp("build-file", name) == 0) {
+        add_build_file(settings, value);
     } else if (strcmp("configure-dir", name) == 0) {
         set_configure_dir(settings, value);
     } else if (strcmp("configure-env", name) == 0) {

--- a/src/main.c
+++ b/src/main.c
@@ -75,6 +75,7 @@ void parse_arguments(int argc, char *argv[], struct Settings *settings) {
         {"source-setup-file",       required_argument, 0, 0},
         {"sudo",                    no_argument      , &settings->install_sudo, 1},
         {"test",                    optional_argument, &settings->do_test, 1},
+        {"test-file",               required_argument, 0, 0},
         {0, 0, 0, 0}
     };
 
@@ -145,6 +146,8 @@ void parse_long_option(const char *name, const char *value, struct Settings *set
         add_source_setup_command(settings, value);
     } else if (strcmp("source-setup-file", name) == 0) {
         add_source_setup_file(settings, value);
+    } else if (strcmp("test-file", name) == 0 && value) {
+        concat_file(settings->test_commands, value);
     } else {
         fprintf(stderr, "long option not implemented: %s\n", name);
         exit(EXIT_FAILURE);

--- a/tests/build/from-file.sh
+++ b/tests/build/from-file.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+. "$(dirname "$0")/../setup.sh"
+
+input_file=$(create_temp_file)
+cat > "$input_file" << EOF
+make prog1
+make prog2
+EOF
+./buildsh name --build-file "$input_file" > "$LOG"
+
+has_output "make prog1"
+has_output "make prog2"
+not_has_output "make --jobs"

--- a/tests/configure/from-file.sh
+++ b/tests/configure/from-file.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+. "$(dirname "$0")/../setup.sh"
+
+input_file=$(create_temp_file)
+cat > "$input_file" << EOF
+./config
+EOF
+./buildsh name --configure-file "$input_file" > "$LOG"
+
+has_output "./config"
+not_has_output "./configure"

--- a/tests/install/from-file.sh
+++ b/tests/install/from-file.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+. "$(dirname "$0")/../setup.sh"
+
+input_file=$(create_temp_file)
+cat > "$input_file" << EOF
+make inst prog1
+EOF
+./buildsh name --install-file "$input_file" > "$LOG"
+
+has_output "make inst prog"
+not_has_output "make install"

--- a/tests/post/from-file-error-handling.sh
+++ b/tests/post/from-file-error-handling.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+
+. "$(dirname "$0")/../setup.sh"
+
+input_file=$(create_temp_file)
+rm "$input_file"
+if ./buildsh name --post-file "$input_file" > "$LOG" ; then
+  error "should have failed for file not found"
+fi
+
+input_file=$(create_temp_file)
+yes "a" | dd of="$input_file" bs=4k count=10000
+echo "end of larger file" >> "$input_file"
+if ./buildsh name --post-file "$input_file" > "$LOG" ; then
+  error "should have failed for very large file"
+fi

--- a/tests/post/from-file.sh
+++ b/tests/post/from-file.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+. "$(dirname "$0")/../setup.sh"
+
+input_file=$(create_temp_file)
+cat > "$input_file" << EOF
+rm $DESTDIR/bin/file
+EOF
+./buildsh name --post-file "$input_file" > "$LOG"
+
+has_output "rm $DESTDIR/bin/file"

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -22,6 +22,10 @@ function error {
     ERRORS=$((ERRORS + 1))
 }
 
+function create_temp_file {
+  mktemp /tmp/buildsh.tmp-XXXXXX
+}
+
 function trap_err {
     error "script error, exit with non-0"
 }

--- a/tests/source-setup/from-file.sh
+++ b/tests/source-setup/from-file.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+. "$(dirname "$0")/../setup.sh"
+
+input_file=$(create_temp_file)
+cat > "$input_file" << EOF
+patch 1
+patch 2
+EOF
+./buildsh name --source-setup-file "$input_file" > "$LOG"
+
+has_output "patch 1"
+has_output "patch 2"

--- a/tests/test/from-file.sh
+++ b/tests/test/from-file.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+. "$(dirname "$0")/../setup.sh"
+
+input_file=$(create_temp_file)
+cat > "$input_file" << EOF
+cd tests
+make test
+cd ..
+EOF
+./buildsh name --test-file "$input_file" > "$LOG"
+
+not_has_output "make check"
+has_output "cd tests"
+has_output "make test"


### PR DESCRIPTION
add `--{source-setup,configure,build,install,post}-file <filename>` options that appends the file contents to the to the command

resolves #1 