### PR TITLE
configure: allow changing script name

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,6 +18,7 @@ TESTS += tests/configure/in-custom-dir.sh
 TESTS += tests/configure/prefix-env.sh
 TESTS += tests/configure/custom-commands.sh
 TESTS += tests/configure/from-file.sh
+TESTS += tests/configure/change-script-name.sh
 TESTS += tests/configure/overflow-errors.sh
 
 TESTS += tests/build/default-make.sh

--- a/src/actions/configure.c
+++ b/src/actions/configure.c
@@ -5,6 +5,10 @@ void set_configure_dir(struct Settings *settings, const char *path) {
     strcpy(settings->config_dir, path);
 }
 
+void set_configure_script_name(struct Settings *settings, const char *path) {
+    strcpy(settings->config_script_name, path);
+}
+
 void add_configure_envvar(struct Settings *settings, const char *envvar) {
     CONCAT_PRINTF(settings->config_env, "%s ", envvar);
 }

--- a/src/generator.c
+++ b/src/generator.c
@@ -50,8 +50,8 @@ void generator_extract_source(struct Settings *settings) {
 
 void generator_configure(struct Settings *settings) {
     APPLY_DEFAULT(settings->configure_commands,
-        "%s%s/configure%s\n",
-        settings->config_env, settings->config_dir, settings->config_options);
+        "%s%s/%s%s\n",
+        settings->config_env, settings->config_dir, settings->config_script_name, settings->config_options);
 }
 
 void generator_build(struct Settings *settings) {
@@ -97,6 +97,9 @@ void generator_finalize_setup(struct Settings *settings) {
     APPLY_DEFAULT(settings->config_dir,
         "%s",
         ".");
+    APPLY_DEFAULT(settings->config_script_name,
+        "%s",
+        "configure");
 
     generator_extract_source(settings);
 

--- a/src/generator.h
+++ b/src/generator.h
@@ -55,6 +55,7 @@ void add_source_setup_command(struct Settings *settings, const char *command);
 void add_source_setup_file(struct Settings *settings, const char *command);
 
 void set_configure_dir(struct Settings *settings, const char *path);
+void set_configure_script_name(struct Settings *settings, const char *path);
 void add_configure_envvar(struct Settings *settings, const char *envvar);
 void add_configure_option(struct Settings *settings, const char *option);
 void add_configure_value(struct Settings *settings, const char *value);

--- a/src/generator.h
+++ b/src/generator.h
@@ -32,6 +32,7 @@ struct Settings {
 
     // default action options
     char config_dir[PATH_MAX + 1];
+    char config_script_name[PATH_MAX + 1];
     char config_env[MAX_COMMAND_LENGTH];
     char config_options[MAX_COMMAND_LENGTH];
     char make_options[MAX_COMMAND_LENGTH];

--- a/src/main.c
+++ b/src/main.c
@@ -64,6 +64,7 @@ void parse_arguments(int argc, char *argv[], struct Settings *settings) {
         {"no-build",                no_argument     , &settings->do_build, 0},
         {"no-configure",            no_argument     , &settings->do_configure, 0},
         {"configure-dir",           required_argument, 0, 0},
+        {"configure-script-name",   required_argument, 0, 0},
         {"configure-env",           required_argument, 0, 0},
         {"configure",               required_argument, 0, 0},
         {"configure-val",           required_argument, 0, 0},
@@ -129,6 +130,8 @@ void parse_long_option(const char *name, const char *value, struct Settings *set
         add_build_file(settings, value);
     } else if (strcmp("configure-dir", name) == 0) {
         set_configure_dir(settings, value);
+    } else if (strcmp("configure-script-name", name) == 0) {
+        set_configure_script_name(settings, value);
     } else if (strcmp("configure-env", name) == 0) {
         add_configure_envvar(settings, value);
     } else if (strcmp("configure", name) == 0) {

--- a/tests/configure/change-script-name.sh
+++ b/tests/configure/change-script-name.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+. "$(dirname "$0")/../setup.sh"
+
+./buildsh name --configure-script-name "ConfScriptName" > "$LOG"
+
+not_has_output "^\./configure$"
+has_output "^\./ConfScriptName$"
+
+./buildsh name --configure-dir abc --configure-script-name "ConfScriptName" > "$LOG"
+
+not_has_output "^\./configure$"
+has_output "^abc/ConfScriptName$"


### PR DESCRIPTION
add `--configure-script-name <name>` option to change the name of the configure script to run.
defaults to `'configure'` (which is called from `./`)