### PR TITLE
Cleanup

### DIFF
--- a/src/generator.c
+++ b/src/generator.c
@@ -95,6 +95,17 @@ void generator_init(struct Settings *settings) {
     settings->do_build = 1;
 }
 
+void generator_output_shell_commands(struct Settings *settings) {
+    run(settings->source_setup);
+    run(settings->build_dir_setup);
+    run(settings->configure_commands);
+    run(settings->build_commands);
+    run(settings->test_commands);
+    run(settings->install_commands);
+    run(settings->install_post);
+    run(settings->cleanup_commands);
+}
+
 void generator_finalize_setup(struct Settings *settings) {
     APPLY_DEFAULT(settings->archive,
         "%s.tar.*",

--- a/src/generator.h
+++ b/src/generator.h
@@ -50,6 +50,7 @@ int run(const char *commands);
 void concat_file(char *buffer, const char *file);
 
 void generator_init(struct Settings *settings);
+void generator_output_shell_commands(struct Settings *settings);
 void generator_finalize_setup(struct Settings *settings);
 
 void add_source_setup_command(struct Settings *settings, const char *command);

--- a/src/main.c
+++ b/src/main.c
@@ -48,12 +48,14 @@ void parse_env_var(struct Settings *settings) {
 void parse_arguments(int argc, char *argv[], struct Settings *settings) {
     const char short_options[] = "";
     struct option long_options[] = {
+        // general
         {"archive",                 required_argument, 0, 'a'},
+        // source and build dir setup
         {"build-outside-sources",   no_argument      , &settings->build_outside_sources, 1},
         {"build-dir-setup",         required_argument, &settings->build_outside_sources, 1},
-        {"build-using",             required_argument, 0, 0},
-        {"build-file",              required_argument, 0, 0},
-        {"no-build",                no_argument     , &settings->do_build, 0},
+        {"source-setup",            required_argument, 0, 0},
+        {"source-setup-file",       required_argument, 0, 0},
+        // configure
         {"no-configure",            no_argument     , &settings->do_configure, 0},
         {"configure-dir",           required_argument, 0, 0},
         {"configure-script-name",   required_argument, 0, 0},
@@ -62,17 +64,23 @@ void parse_arguments(int argc, char *argv[], struct Settings *settings) {
         {"configure-val",           required_argument, 0, 0},
         {"configure-using",         required_argument, 0, 0},
         {"configure-file",          required_argument, 0, 0},
-        {"install-using",           required_argument, 0, 0},
-        {"install-file",            required_argument, 0, 0},
+        // build
+        {"build-using",             required_argument, 0, 0},
+        {"build-file",              required_argument, 0, 0},
+        {"no-build",                no_argument     , &settings->do_build, 0},
         {"make",                    required_argument, 0, 0},
         {"max-jobs",                required_argument, 0, 0},
-        {"post",                    required_argument, 0, 0},
-        {"post-file",               required_argument, 0, 0},
-        {"source-setup",            required_argument, 0, 0},
-        {"source-setup-file",       required_argument, 0, 0},
-        {"sudo",                    no_argument      , &settings->install_sudo, 1},
+        // test
         {"test",                    optional_argument, &settings->do_test, 1},
         {"test-file",               required_argument, 0, 0},
+        // install
+        {"install-using",           required_argument, 0, 0},
+        {"install-file",            required_argument, 0, 0},
+        {"sudo",                    no_argument      , &settings->install_sudo, 1},
+        // post-install
+        {"post",                    required_argument, 0, 0},
+        {"post-file",               required_argument, 0, 0},
+        // cleanup
         {0, 0, 0, 0}
     };
 

--- a/src/main.c
+++ b/src/main.c
@@ -22,15 +22,7 @@ int main(int argc, char *argv[]) {
     struct Settings settings;
     generator_init(&settings);
     parse_settings(argc, argv, &settings);
-
-    run(settings.source_setup);
-    run(settings.build_dir_setup);
-    run(settings.configure_commands);
-    run(settings.build_commands);
-    run(settings.test_commands);
-    run(settings.install_commands);
-    run(settings.install_post);
-    run(settings.cleanup_commands);
+    generator_output_shell_commands(&settings);
 
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -20,6 +20,7 @@ int main(int argc, char *argv[]) {
     }
 
     struct Settings settings;
+    generator_init(&settings);
     parse_settings(argc, argv, &settings);
 
     run(settings.source_setup);
@@ -39,8 +40,6 @@ void print_version() {
 }
 
 void parse_settings(int argc, char *argv[], struct Settings *settings) {
-    generator_init(settings);
-
     parse_env_var(settings);
     parse_arguments(argc, argv, settings);
     parse_name_from_remaining(argc, argv, settings);

--- a/src/main.c
+++ b/src/main.c
@@ -22,6 +22,7 @@ int main(int argc, char *argv[]) {
     struct Settings settings;
     generator_init(&settings);
     parse_settings(argc, argv, &settings);
+    generator_finalize_setup(&settings);
     generator_output_shell_commands(&settings);
 
     return 0;
@@ -35,8 +36,6 @@ void parse_settings(int argc, char *argv[], struct Settings *settings) {
     parse_env_var(settings);
     parse_arguments(argc, argv, settings);
     parse_name_from_remaining(argc, argv, settings);
-
-    generator_finalize_setup(settings);
 }
 
 void parse_env_var(struct Settings *settings) {


### PR DESCRIPTION
- re-arrange generator code (move output into new `generator_output_shell_commands`)
- group cli argument long options based on action type