### PR TITLE
Feat: build and install values for make

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,6 +37,7 @@ TESTS += tests/test/from-file.sh
 
 TESTS += tests/install/default-make-install.sh
 TESTS += tests/install/destdir.sh
+TESTS += tests/install/make-install-vars.sh
 TESTS += tests/install/sudo.sh
 TESTS += tests/install/custom.sh
 TESTS += tests/install/from-file.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,6 +26,7 @@ TESTS += tests/build/default-make.sh
 TESTS += tests/build/disabled.sh
 TESTS += tests/build/make-max-jobs.sh
 TESTS += tests/build/make-targets.sh
+TESTS += tests/build/make-vars.sh
 TESTS += tests/build/custom-commands.sh
 TESTS += tests/build/from-file.sh
 

--- a/src/actions/install.c
+++ b/src/actions/install.c
@@ -5,6 +5,10 @@ void set_makeinstall_destdir(struct Settings *settings, const char *path) {
     CONCAT_PRINTF(settings->install_options, " DESTDIR=%s", path);
 }
 
+void add_makeinstall_option(struct Settings *settings, const char *option) {
+    CONCAT_PRINTF(settings->install_options, " %s", option);
+}
+
 void add_install_command(struct Settings *settings, const char *command) {
     CONCAT_LINE(settings->install_commands, command);
 }

--- a/src/generator.h
+++ b/src/generator.h
@@ -70,6 +70,7 @@ void add_make_option(struct Settings *settings, const char *option);
 void add_build_file(struct Settings *settings, const char *file);
 
 void set_makeinstall_destdir(struct Settings *settings, const char *path);
+void add_makeinstall_option(struct Settings *settings, const char *option);
 void add_install_command(struct Settings *settings, const char *command);
 void add_install_file(struct Settings *settings, const char *file);
 

--- a/src/main.c
+++ b/src/main.c
@@ -74,6 +74,7 @@ void parse_arguments(int argc, char *argv[], struct Settings *settings) {
         {"test",                    optional_argument, &settings->do_test, 1},
         {"test-file",               required_argument, 0, 0},
         // install
+        {"make-install",            required_argument, 0, 0},
         {"install-using",           required_argument, 0, 0},
         {"install-file",            required_argument, 0, 0},
         {"sudo",                    no_argument      , &settings->install_sudo, 1},
@@ -153,6 +154,8 @@ void parse_long_option(const char *name, const char *value, struct Settings *set
         add_make_option(settings, value);
     } else if (strcmp("max-jobs", name) == 0) {
         settings->max_make_jobs = atoi(value);
+    } else if (strcmp("make-install", name) == 0) {
+        add_makeinstall_option(settings, value);
     } else if (strcmp("post", name) == 0) {
         add_post_command(settings, value);
     } else if (strcmp("post-file", name) == 0) {

--- a/tests/build/make-vars.sh
+++ b/tests/build/make-vars.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+. "$(dirname "$0")/../setup.sh"
+
+./buildsh name --make prefix=/usr --make foo=bar > "$LOG"
+
+has_output "^make --jobs .*  prefix=/usr foo=bar"

--- a/tests/install/make-install-vars.sh
+++ b/tests/install/make-install-vars.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+. "$(dirname "$0")/../setup.sh"
+
+./buildsh name --make-install prefix=/usr --make-install foo=bar > "$LOG"
+
+has_output "^make prefix=/usr foo=bar install"


### PR DESCRIPTION
add a test to show that `--make <arg>` can be used to pass ex `prefix=/usr` to make

add --make-install that appends the strings as options to the build command. this can be used ex to generate `make prefix=/usr install`

implements #3