### PR TITLE
Fix: clear from file buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.2
+
+### Fixed
+
+- Buffer overflow when loading from multiple files
+
 ## 0.2.1
 
 ### Fixed

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 bin_PROGRAMS = buildsh
-EXTRA_DIST = src/utils.h $(TESTS) tests/setup.sh
+EXTRA_DIST = src/utils.h $(TESTS) tests/general/clear-from-file-buffers.expected.out tests/setup.sh
 
 TESTS =
 
@@ -46,6 +46,8 @@ TESTS += tests/post/post-install.sh
 TESTS += tests/post/cleanup.sh
 TESTS += tests/post/from-file.sh
 TESTS += tests/post/from-file-error-handling.sh
+
+TESTS += tests/general/clear-from-file-buffers.sh
 
 buildsh_CFLAGS = -ggdb -pedantic -Wall -Wextra
 buildsh_SOURCES = src/main.c

--- a/src/generator.c
+++ b/src/generator.c
@@ -1,3 +1,4 @@
+#include <ctype.h>
 #include "generator.h"
 #include "utils.h"
 
@@ -24,6 +25,9 @@ void concat_file(char *destination, const char *file) {
         exit_failure_printf("file %s too large\n", file);
     }
 
+    while (size > 0 && isspace(buffer[size - 1])) {
+      --size;
+    }
     buffer[size] = 0;
     CONCAT_LINE(destination, buffer);
 }

--- a/src/generator.c
+++ b/src/generator.c
@@ -24,6 +24,7 @@ void concat_file(char *destination, const char *file) {
         exit_failure_printf("file %s too large\n", file);
     }
 
+    buffer[size] = 0;
     CONCAT_LINE(destination, buffer);
 }
 

--- a/tests/general/clear-from-file-buffers.expected.out
+++ b/tests/general/clear-from-file-buffers.expected.out
@@ -2,24 +2,18 @@ tar xf name.tar.*
 cd name
 patch -Np1 -i ../dummy.patch
 
-
 ./config --qwe
-
 
 make target1
 make target2
 
-
 make test1
 make test2
-
 
 make inst prog1
 make inst prog2
 
-
 mv foo bar
-
 
 cd ..
 rm -rf name

--- a/tests/general/clear-from-file-buffers.expected.out
+++ b/tests/general/clear-from-file-buffers.expected.out
@@ -1,0 +1,26 @@
+tar xf name.tar.*
+cd name
+patch -Np1 -i ../dummy.patch
+
+
+./config --qwe
+
+
+make target1
+make target2
+
+
+make test1
+make test2
+
+
+make inst prog1
+make inst prog2
+
+
+mv foo bar
+
+
+cd ..
+rm -rf name
+

--- a/tests/general/clear-from-file-buffers.sh
+++ b/tests/general/clear-from-file-buffers.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -e
+
+. "$(dirname "$0")/../setup.sh"
+
+source_setup_file=$(create_temp_file)
+cat > "$source_setup_file" << EOF
+patch -Np1 -i ../dummy.patch
+EOF
+
+config_file=$(create_temp_file)
+cat > "$config_file" << EOF
+./config --qwe
+EOF
+
+build_file=$(create_temp_file)
+cat > "$build_file" << EOF
+make target1
+make target2
+EOF
+
+test_file=$(create_temp_file)
+cat > "$test_file" << EOF
+make test1
+make test2
+EOF
+
+install_file=$(create_temp_file)
+cat > "$install_file" << EOF
+make inst prog1
+make inst prog2
+EOF
+
+post_file=$(create_temp_file)
+cat > "$post_file" << EOF
+mv foo bar
+EOF
+
+./buildsh name \
+  --source-setup-file "$source_setup_file" \
+  --configure-file "$config_file" \
+  --build-file "$build_file" \
+  --test-file "$test_file" \
+  --install-file "$install_file" \
+  --post-file "$post_file" \
+  > "$LOG"
+
+expected="${0/sh/expected.out}"
+diff --unified "$expected" "$LOG"


### PR DESCRIPTION
add null terminator in buffer after reading file for `--...-file`
options